### PR TITLE
Added support for @run-at

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The following JSON keys are supported by GreaseMonkey:
 - `noframes` - (`string`) - Whether or not to run in frames
 - `require` - (`string[]`) - Scripts to include within the script
 - `resource` - (`string[]`) - Resources to include within the script
+- `run-at` - (`string`) - When to run the script
 - `version` - (`string`) - Version number of the script
 - `updateURL` - (`string`) - URL location for script updates
 - `downloadURL` - (`string`) - URL location for script download

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export type GorillaConfig = {
   noframes?: string;
   require?: string[];
   resource?: string[];
+  "run-at"?: string;
   updateURL?: string;
   downloadURL?: string;
   version?: string;
@@ -49,6 +50,7 @@ export const VALID_GORILLA_CONFIG_KEYS = [
   "noframes",
   "require",
   "resource",
+  "run-at",
   "version",
   "updateURL",
   "downloadURL",


### PR DESCRIPTION
Adds support for [@run-at](https://wiki.greasespot.net/Metadata_Block#@run-at) listed on the officially supported Metadata Block.